### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Ask Claude to help you with tasks like:
 - "Find and compare prices for a specific product"
 - "Fill out an online job application"
 
+<a href="https://glama.ai/mcp/servers/tbd32geble"><img width="380" height="200" src="https://glama.ai/mcp/servers/tbd32geble/badge" alt="Steel Server MCP server" /></a>
+
 ## 🚀 Quick Start
 
 Below is a streamlined guide to run Steel Voyager inside Claude Desktop. You only need to adjust the environment options to switch between Steel Cloud and a local/self-hosted instance.


### PR DESCRIPTION
This PR adds a badge for the [Steel MCP Server](https://glama.ai/mcp/servers/tbd32geble) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/tbd32geble"><img width="380" height="200" src="https://glama.ai/mcp/servers/tbd32geble/badge" alt="Steel Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.